### PR TITLE
Reactのインポートを最適化し、不要なインポートを削除

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,5 +1,4 @@
 import { Tabs } from "expo-router";
-import React from "react";
 import { Platform } from "react-native";
 
 import { HapticTab } from "@/components/HapticTab";
@@ -32,7 +31,11 @@ export default function TabLayout() {
 				options={{
 					title: "都へのコメント",
 					tabBarIcon: ({ color }) => (
-						<IconSymbol size={28} name="bubble.left.and.bubble.right.fill" color={color} />
+						<IconSymbol
+							size={28}
+							name="bubble.left.and.bubble.right.fill"
+							color={color}
+						/>
 					),
 				}}
 			/>

--- a/app/pages/opinion.tsx
+++ b/app/pages/opinion.tsx
@@ -1,6 +1,6 @@
 import * as Location from "expo-location";
 import { router } from "expo-router";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { KeyboardAvoidingView, Platform, StyleSheet, View } from "react-native";
 import type { LatLng } from "react-native-maps";
 import {

--- a/components/LocationMap.tsx
+++ b/components/LocationMap.tsx
@@ -1,5 +1,5 @@
 import * as Location from "expo-location";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 import OpenStreetMap from "./OpenStreetMap";
 

--- a/components/OpenStreetMap.tsx
+++ b/components/OpenStreetMap.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 import { WebView } from "react-native-webview";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- リファクタリング
  - React のデフォルトインポートを削除し、JSX ランタイムに合わせてレイアウト/意見ページ/LocationMap/OpenStreetMap を更新。ビルドの一貫性と保守性を改善。機能や表示の変化はありません。
- スタイル
  - タブのアイコン記述を複数行に整形し、可読性を向上。動作への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->