### PR TITLE
OpenStreetMapコンポーネントにdisableMapClickプロパティを追加し、マップクリックの無効化機能を実装

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -254,6 +254,7 @@ export default function LocationMap() {
 						const post = posts.find((p) => p.id === markerId);
 						if (post) setSelected(post);
 					}}
+					disableMapClick={true}
 				/>
 
 				<TouchableOpacity

--- a/components/OpenStreetMap.tsx
+++ b/components/OpenStreetMap.tsx
@@ -25,6 +25,7 @@ type Props = {
 		description?: string;
 	}>;
 	onMarkerPress?: (markerId: string) => void;
+	disableMapClick?: boolean;
 };
 
 export default function OpenStreetMap({
@@ -34,6 +35,7 @@ export default function OpenStreetMap({
 	onPress,
 	markers = [],
 	onMarkerPress,
+	disableMapClick = false,
 }: Props) {
 	const webViewRef = useRef<WebView>(null);
 	const [isLoading, setIsLoading] = useState(true);
@@ -65,6 +67,9 @@ export default function OpenStreetMap({
             attribution: '© OpenStreetMap contributors'
           }).addTo(map);
 
+          ${
+						!disableMapClick
+							? `
           map.on('click', function(e) {
             const lat = e.latlng.lat;
             const lng = e.latlng.lng;
@@ -93,6 +98,9 @@ export default function OpenStreetMap({
               longitude: lng
             }));
           });
+          `
+							: ""
+					}
 
           // 初期マーカーの設定
           ${


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 地図のタップ操作を無効化できる設定を追加。空白部分のタップで選択が解除されなくなります。
  - マーカーのタップによる選択やドラッグ挙動は従来どおり維持。
  - 対象画面で本設定を有効化し、誤タップによる状態リセットを防止。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->