### PR TITLE
LocationMapの中心をマーカー位置に基づくよう修正

### DIFF
--- a/app/pages/opinion.tsx
+++ b/app/pages/opinion.tsx
@@ -35,19 +35,24 @@ export default function OpinionScreen() {
 	const [sending, setSending] = useState(false);
 
 	const [markerCoords, setMarkerCoords] = useState<LatLng | null>(null);
+	const [isInitialized, setIsInitialized] = useState(false);
 
-	// 初期位置を取得してマーカーの座標を設定
+	// 初期位置を取得してマーカーの座標を設定（一度だけ実行）
 	useEffect(() => {
 		(async () => {
 			const { status } = await Location.requestForegroundPermissionsAsync();
 			if (status !== "granted") return;
 
-			setMarkerCoords({
-				latitude: location!.coords.latitude,
-				longitude: location!.coords.longitude,
-			});
+			// 初期化が未完了で、locationが存在する場合のみ設定
+			if (!isInitialized && location) {
+				setMarkerCoords({
+					latitude: location.coords.latitude,
+					longitude: location.coords.longitude,
+				});
+				setIsInitialized(true);
+			}
 		})();
-	}, [location]);
+	}, [location, isInitialized]); // isInitializedフラグで初期化を制御
 
 	// 意見を送信する関数
 	const handleSendOpinion = async () => {

--- a/components/LocationMap.tsx
+++ b/components/LocationMap.tsx
@@ -37,15 +37,9 @@ export default function LocationMap({
 			const { status } = await Location.requestForegroundPermissionsAsync();
 			if (status !== "granted") return;
 
-			if (onLocationLoaded) onLocationLoaded(location!);
-			if (!markerCoords) {
-				setMarkerCoords({
-					latitude: location!.coords.latitude,
-					longitude: location!.coords.longitude,
-				});
-			}
+			if (onLocationLoaded && location) onLocationLoaded(location);
 		})();
-	}, [setMarkerCoords, markerCoords, onLocationLoaded, location]);
+	}, [onLocationLoaded, location]);
 
 	if (!location) {
 		return (
@@ -56,13 +50,19 @@ export default function LocationMap({
 		);
 	}
 
+	// マーカーが設定されている場合はマーカー位置を中心に、そうでなければ現在地を中心に
+	const mapCenter = markerCoords || {
+		latitude: location.coords.latitude,
+		longitude: location.coords.longitude,
+	};
+
 	return (
 		<OpenStreetMap
 			markerCoords={markerCoords}
 			setMarkerCoords={setMarkerCoords}
 			initialRegion={{
-				latitude: location.coords.latitude,
-				longitude: location.coords.longitude,
+				latitude: mapCenter.latitude,
+				longitude: mapCenter.longitude,
 				latitudeDelta: 0.01,
 				longitudeDelta: 0.01,
 			}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* バグ修正
  * 初回の現在地のみを基準にピンを一度だけ配置し、その後の位置更新で上書きされないよう修正。
  * ピンがある場合はピン、ない場合は現在地を地図の中心にするよう調整。
  * 位置情報未取得時はローディング表示を継続し、表示の安定性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->