### PR TITLE
ズームコントロールの位置を固定し、カスタムズームコントロールを追加

### DIFF
--- a/components/OpenStreetMap.tsx
+++ b/components/OpenStreetMap.tsx
@@ -54,6 +54,15 @@ export default function OpenStreetMap({
       <style>
         body { margin: 0; padding: 0; }
         #map { height: 100vh; width: 100vw; }
+        
+        .leaflet-control-zoom {
+          position: fixed !important;
+          top: auto !important;
+          bottom: 30px !important;
+          left: 15px !important;
+          z-index: 1000 !important;
+        }
+        
       </style>
     </head>
     <body>
@@ -64,7 +73,14 @@ export default function OpenStreetMap({
         let markers = [];
 
         function initMap() {
-          map = L.map('map').setView([${initialRegion.latitude}, ${initialRegion.longitude}], 15);
+          map = L.map('map', {
+            zoomControl: false  // デフォルトのズームコントロールを無効化
+          }).setView([${initialRegion.latitude}, ${initialRegion.longitude}], 15);
+          
+          // カスタムズームコントロールを下部に追加
+          L.control.zoom({
+            position: 'bottomleft'
+          }).addTo(map);
           
           L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: '© OpenStreetMap contributors'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - 地図のズームコントロールを固定の左下配置に変更し、視認性と操作性を向上。
  - スクロールや他要素の重なりでも位置が維持されるよう調整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->