### PR TITLE
東京都アプリスタイルの実装とカラーパレットの追加

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,11 +9,13 @@ import { useColorScheme } from "@/hooks/useColorScheme";
 
 export default function TabLayout() {
 	const colorScheme = useColorScheme();
+	const colors = Colors[colorScheme ?? "light"];
 
 	return (
 		<Tabs
 			screenOptions={{
-				tabBarActiveTintColor: Colors[colorScheme ?? "light"].tint,
+				tabBarActiveTintColor: colors.tokyoGreen,
+				tabBarInactiveTintColor: colors.icon,
 				headerShown: false,
 				tabBarButton: HapticTab,
 				tabBarBackground: TabBarBackground,
@@ -21,9 +23,24 @@ export default function TabLayout() {
 					ios: {
 						// Use a transparent background on iOS to show the blur effect
 						position: "absolute",
+						backgroundColor: "rgba(255, 255, 255, 0.9)",
+						borderTopWidth: 1,
+						borderTopColor: colors.tokyoLightGreen,
 					},
-					default: {},
+					default: {
+						backgroundColor: "white",
+						borderTopWidth: 2,
+						borderTopColor: colors.tokyoGreen,
+						elevation: 8,
+						shadowColor: colors.shadowColor,
+						shadowOpacity: 0.1,
+						shadowRadius: 4,
+					},
 				}),
+				tabBarLabelStyle: {
+					fontSize: 12,
+					fontWeight: "600",
+				},
 			}}
 		>
 			<Tabs.Screen

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,6 +17,8 @@ import {
 	TouchableOpacity,
 	View,
 } from "react-native";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import { userInfo } from "@/testUserInfo";
 import OpenStreetMap from "../../components/OpenStreetMap";
 import { userApiClient } from "../apiClients/UserApiClient";
@@ -67,6 +69,9 @@ type ReactionInfo = {
 };
 
 function LocationMap() {
+	const colorScheme = useColorScheme();
+	const colors = Colors[colorScheme ?? "light"];
+	const styles = createStyles(colors);
 	const { location, setLocation } = useLocationContext();
 	const { shouldRefresh, resetRefresh } = useOpinionContext();
 	const [posts, setPosts] = useState<Spot[]>([]);
@@ -332,12 +337,12 @@ function LocationMap() {
 							<Text style={{ marginLeft: 8 }}>
 								{reactionInfo?.ReactionCount}
 							</Text>
-							<Pressable
+							<TouchableOpacity
 								onPress={() => setSelected(null)}
-								style={{ marginLeft: "auto" }}
+								style={styles.closeButton}
 							>
-								<Text style={{ color: "blue" }}>閉じる</Text>
-							</Pressable>
+								<Text style={styles.closeButtonText}>閉じる</Text>
+							</TouchableOpacity>
 						</View>
 
 						<View style={styles.commentListContainer}>
@@ -363,30 +368,18 @@ function LocationMap() {
 							) : (
 								<Text style={{ color: "#666" }}>コメントはまだありません</Text>
 							)}
-							<View
-								style={{
-									flexDirection: "row",
-									alignItems: "center",
-									marginTop: 8,
-								}}
-							>
+							<View style={styles.inputContainer}>
 								<TextInput
-									style={{
-										flex: 1,
-										borderColor: "#ccc",
-										borderWidth: 1,
-										borderRadius: 4,
-										padding: 12,
-									}}
+									style={styles.textInput}
 									placeholder="コメントを入力..."
 									value={newComment}
 									onChangeText={setNewComment}
 								/>
 								<TouchableOpacity
 									onPress={handleCommentSubmit}
-									style={{ marginLeft: 8 }}
+									style={styles.sendButton}
 								>
-									<Text style={{ color: "blue" }}>送信</Text>
+									<Text style={styles.sendButtonText}>送信</Text>
 								</TouchableOpacity>
 							</View>
 						</View>
@@ -397,102 +390,171 @@ function LocationMap() {
 	);
 }
 
-const styles = StyleSheet.create({
-	center: { flex: 1, justifyContent: "center", alignItems: "center" },
-	card: {
-		position: "absolute",
-		bottom: 0,
-		width: Dimensions.get("window").width,
-		backgroundColor: "white",
-		padding: 16,
-		borderTopLeftRadius: 12,
-		borderTopRightRadius: 12,
-		shadowColor: "#000",
-		shadowOpacity: 0.2,
-		shadowRadius: 6,
-		elevation: 6,
-		maxHeight: windowHeight * 0.4,
-	},
-	row: { flexDirection: "row", alignItems: "center", marginTop: 8 },
-	button: { padding: 4 },
-	commentListContainer: {
-		marginTop: 12,
-		flex: 1,
-		maxHeight: windowHeight * 0.25,
-	},
-	commentHeader: {
-		fontWeight: "600",
-		marginBottom: 6,
-		fontSize: 16,
-	},
-	commentRow: {
-		flexDirection: "row",
-		paddingVertical: 6,
-		borderBottomColor: "#eee",
-		borderBottomWidth: 1,
-		alignItems: "flex-start",
-	},
-	avatar: {
-		backgroundColor: "#17882e",
-		width: 32,
-		height: 32,
-		borderRadius: 16,
-		alignItems: "center",
-		justifyContent: "center",
-	},
-	commentAuthor: {
-		fontWeight: "600",
-	},
-	timestamp: {
-		fontSize: 10,
-		color: "#888",
-		marginTop: 2,
-	},
-	refreshButton: {
-		position: "absolute",
-		bottom: 30,
-		right: 20,
-		backgroundColor: "#17882e",
-		width: 56,
-		height: 56,
-		borderRadius: 28,
-		alignItems: "center",
-		justifyContent: "center",
-		elevation: 6,
-		shadowColor: "#000",
-		shadowOpacity: 0.3,
-		shadowRadius: 4,
-	},
-	opinionButton: {
-		position: "absolute",
-		bottom: 30 + 56 + 10,
-		right: 20,
-		backgroundColor: "#17882e",
-		width: 56,
-		height: 56,
-		borderRadius: 28,
-		alignItems: "center",
-		justifyContent: "center",
-		elevation: 6,
-		shadowColor: "#000",
-		shadowOpacity: 0.3,
-		shadowRadius: 4,
-	},
-	chatButton: {
-		position: "absolute",
-		bottom: 30 + 56 + 10 + 56 + 10,
-		right: 20,
-		backgroundColor: "#17882e",
-		width: 56,
-		height: 56,
-		borderRadius: 28,
-		alignItems: "center",
-		justifyContent: "center",
-		elevation: 6,
-		shadowColor: "#000",
-		shadowOpacity: 0.3,
-		shadowRadius: 4,
-	},
-});
+// 東京都アプリスタイルのスタイルシート
+const createStyles = (colors: any) =>
+	StyleSheet.create({
+		center: {
+			flex: 1,
+			justifyContent: "center",
+			alignItems: "center",
+			backgroundColor: colors.tokyoLightGreen,
+		},
+		card: {
+			position: "absolute",
+			bottom: 0,
+			width: Dimensions.get("window").width,
+			backgroundColor: colors.cardBackground,
+			padding: 20,
+			borderTopLeftRadius: 20,
+			borderTopRightRadius: 20,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.15,
+			shadowRadius: 10,
+			elevation: 8,
+			maxHeight: windowHeight * 0.4,
+			borderTopWidth: 3,
+			borderTopColor: colors.tokyoGreen,
+		},
+		row: {
+			flexDirection: "row",
+			alignItems: "center",
+			marginTop: 12,
+			paddingBottom: 8,
+			borderBottomWidth: 1,
+			borderBottomColor: colors.tokyoLightGreen,
+		},
+		button: {
+			padding: 8,
+			borderRadius: 8,
+		},
+		commentListContainer: {
+			marginTop: 16,
+			flex: 1,
+			maxHeight: windowHeight * 0.25,
+		},
+		commentHeader: {
+			fontWeight: "700",
+			marginBottom: 12,
+			fontSize: 18,
+			color: colors.tokyoGreen,
+		},
+		commentRow: {
+			flexDirection: "row",
+			paddingVertical: 12,
+			borderBottomColor: colors.tokyoLightGreen,
+			borderBottomWidth: 1,
+			alignItems: "flex-start",
+		},
+		avatar: {
+			backgroundColor: colors.tokyoGreen,
+			width: 36,
+			height: 36,
+			borderRadius: 18,
+			alignItems: "center",
+			justifyContent: "center",
+		},
+		commentAuthor: {
+			fontWeight: "700",
+			color: colors.tokyoGreenDark,
+			fontSize: 14,
+		},
+		timestamp: {
+			fontSize: 11,
+			color: "#888",
+			marginTop: 4,
+		},
+		refreshButton: {
+			position: "absolute",
+			bottom: 30,
+			right: 20,
+			backgroundColor: colors.tokyoGreen,
+			width: 60,
+			height: 60,
+			borderRadius: 30,
+			alignItems: "center",
+			justifyContent: "center",
+			elevation: 8,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.25,
+			shadowRadius: 6,
+			borderWidth: 2,
+			borderColor: "white",
+		},
+		opinionButton: {
+			position: "absolute",
+			bottom: 30 + 60 + 15,
+			right: 20,
+			backgroundColor: colors.tokyoGreenLight,
+			width: 60,
+			height: 60,
+			borderRadius: 30,
+			alignItems: "center",
+			justifyContent: "center",
+			elevation: 8,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.25,
+			shadowRadius: 6,
+			borderWidth: 2,
+			borderColor: "white",
+		},
+		chatButton: {
+			position: "absolute",
+			bottom: 30 + 60 + 15 + 60 + 15,
+			right: 20,
+			backgroundColor: colors.tokyoGreenDark,
+			width: 60,
+			height: 60,
+			borderRadius: 30,
+			alignItems: "center",
+			justifyContent: "center",
+			elevation: 8,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.25,
+			shadowRadius: 6,
+			borderWidth: 2,
+			borderColor: "white",
+		},
+		inputContainer: {
+			flexDirection: "row",
+			alignItems: "center",
+			marginTop: 12,
+			backgroundColor: colors.tokyoLightGreen,
+			borderRadius: 12,
+			padding: 4,
+		},
+		textInput: {
+			flex: 1,
+			borderColor: colors.tokyoGreen,
+			borderWidth: 1,
+			borderRadius: 8,
+			padding: 12,
+			backgroundColor: "white",
+			fontSize: 14,
+		},
+		sendButton: {
+			marginLeft: 8,
+			backgroundColor: colors.tokyoGreen,
+			paddingHorizontal: 16,
+			paddingVertical: 12,
+			borderRadius: 8,
+		},
+		sendButtonText: {
+			color: "white",
+			fontWeight: "600",
+			fontSize: 14,
+		},
+		closeButton: {
+			marginLeft: "auto",
+			backgroundColor: colors.tokyoLightGreen,
+			paddingHorizontal: 12,
+			paddingVertical: 6,
+			borderRadius: 6,
+		},
+		closeButtonText: {
+			color: colors.tokyoGreenDark,
+			fontWeight: "600",
+			fontSize: 14,
+		},
+	});
 
 export default React.memo(LocationMap);

--- a/app/pages/chat.tsx
+++ b/app/pages/chat.tsx
@@ -4,10 +4,13 @@ import {
 	FlatList,
 	Pressable,
 	SafeAreaView,
+	StyleSheet,
 	Text,
 	TextInput,
 	View,
 } from "react-native";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 // ===== Types =====
 type Msg = { id: string; text: string; from: "me" | "bot"; createdAt: number };
@@ -42,8 +45,17 @@ const CHAT_ENDPOINT = `${API_BASE_URL}/user-chat/chat`;
 const MAIL_ADDRESS = "test@example.com"; // sample に合わせる
 
 export default function ChatScreen() {
+	const colorScheme = useColorScheme();
+	const colors = Colors[colorScheme ?? "light"];
+	const styles = createStyles(colors);
+
 	const [messages, setMessages] = useState<Msg[]>([
-		{ id: "1", text: "こんにちは！", from: "bot", createdAt: Date.now() },
+		{
+			id: "1",
+			text: "こんにちは！東京都への意見やご質問をお聞かせください。",
+			from: "bot",
+			createdAt: Date.now(),
+		},
 	]);
 	const [text, setText] = useState("");
 	const inputRef = useRef<TextInput>(null);
@@ -200,69 +212,175 @@ export default function ChatScreen() {
 	};
 
 	return (
-		<SafeAreaView style={{ flex: 1 }}>
+		<SafeAreaView style={styles.container}>
+			<View style={styles.header}>
+				<Text style={styles.headerTitle}>東京都チャットサポート</Text>
+				<Text style={styles.headerSubtitle}>
+					ご質問やご意見をお聞かせください
+				</Text>
+			</View>
+
 			<FlatList
 				inverted
 				data={messages}
 				keyExtractor={(item) => item.id}
 				renderItem={({ item }) => (
-					<View
-						style={{
-							padding: 8,
-							alignItems: item.from === "me" ? "flex-end" : "flex-start",
-						}}
-					>
+					<View style={styles.messageContainer}>
 						<View
-							style={{
-								backgroundColor: item.from === "me" ? "#17882e" : "#e5e5ea",
-								paddingHorizontal: 12,
-								paddingVertical: 8,
-								borderRadius: 16,
-								maxWidth: "80%",
-							}}
+							style={[
+								styles.messageBubble,
+								item.from === "me" ? styles.myMessage : styles.botMessage,
+							]}
 						>
-							<Text style={{ color: item.from === "me" ? "#fff" : "#000" }}>
+							<Text
+								style={[
+									styles.messageText,
+									item.from === "me"
+										? styles.myMessageText
+										: styles.botMessageText,
+								]}
+							>
 								{item.text}
 							</Text>
 						</View>
 					</View>
 				)}
-				contentContainerStyle={{ paddingVertical: 8 }}
+				contentContainerStyle={styles.messagesList}
 			/>
 
-			<View
-				style={{ flexDirection: "row", padding: 8, gap: 8, marginBottom: 30 }}
-			>
+			<View style={styles.inputContainer}>
 				<TextInput
 					ref={inputRef}
 					value={text}
 					onChangeText={setText}
-					placeholder="メッセージを入力"
-					style={{
-						flex: 1,
-						borderWidth: 1,
-						borderColor: "#ccc",
-						borderRadius: 20,
-						paddingHorizontal: 12,
-						height: 40,
-					}}
+					placeholder="メッセージを入力してください..."
+					style={styles.textInput}
 					onSubmitEditing={send}
 					returnKeyType="send"
+					multiline
 				/>
-				<Pressable
-					onPress={send}
-					style={{
-						height: 40,
-						paddingHorizontal: 16,
-						borderRadius: 20,
-						backgroundColor: "#17882e",
-						alignItems: "center",
-						justifyContent: "center",
-					}}
-				>
-					<Text style={{ color: "white", fontWeight: "600" }}>送信</Text>
+				<Pressable onPress={send} style={styles.sendButton}>
+					<Text style={styles.sendButtonText}>送信</Text>
 				</Pressable>
 			</View>
 		</SafeAreaView>
 	);
 }
+
+// 東京都アプリスタイルのスタイルシート
+const createStyles = (colors: any) =>
+	StyleSheet.create({
+		container: {
+			flex: 1,
+			backgroundColor: colors.tokyoLightGreen,
+		},
+		header: {
+			backgroundColor: colors.tokyoGreen,
+			paddingVertical: 16,
+			paddingHorizontal: 20,
+			borderBottomLeftRadius: 16,
+			borderBottomRightRadius: 16,
+			elevation: 4,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.1,
+			shadowRadius: 4,
+		},
+		headerTitle: {
+			color: "white",
+			fontSize: 20,
+			fontWeight: "700",
+			textAlign: "center",
+		},
+		headerSubtitle: {
+			color: "white",
+			fontSize: 14,
+			textAlign: "center",
+			marginTop: 4,
+			opacity: 0.9,
+		},
+		messagesList: {
+			paddingVertical: 12,
+			paddingHorizontal: 8,
+		},
+		messageContainer: {
+			padding: 8,
+			alignItems: "flex-start",
+		},
+		messageBubble: {
+			paddingHorizontal: 16,
+			paddingVertical: 12,
+			borderRadius: 20,
+			maxWidth: "85%",
+			elevation: 2,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.1,
+			shadowRadius: 2,
+		},
+		myMessage: {
+			backgroundColor: colors.tokyoGreen,
+			alignSelf: "flex-end",
+			borderBottomRightRadius: 6,
+		},
+		botMessage: {
+			backgroundColor: "white",
+			alignSelf: "flex-start",
+			borderBottomLeftRadius: 6,
+			borderLeftWidth: 3,
+			borderLeftColor: colors.tokyoGreenLight,
+		},
+		messageText: {
+			fontSize: 16,
+			lineHeight: 22,
+		},
+		myMessageText: {
+			color: "white",
+			fontWeight: "500",
+		},
+		botMessageText: {
+			color: colors.text,
+			fontWeight: "400",
+		},
+		inputContainer: {
+			flexDirection: "row",
+			padding: 12,
+			gap: 12,
+			marginBottom: 20,
+			backgroundColor: "white",
+			marginHorizontal: 8,
+			borderRadius: 16,
+			elevation: 4,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.1,
+			shadowRadius: 4,
+			borderTopWidth: 2,
+			borderTopColor: colors.tokyoGreen,
+		},
+		textInput: {
+			flex: 1,
+			borderWidth: 1,
+			borderColor: colors.tokyoLightGreen,
+			borderRadius: 12,
+			paddingHorizontal: 16,
+			paddingVertical: 12,
+			fontSize: 16,
+			backgroundColor: colors.tokyoLightGreen,
+			maxHeight: 100,
+		},
+		sendButton: {
+			paddingHorizontal: 20,
+			paddingVertical: 12,
+			borderRadius: 12,
+			backgroundColor: colors.tokyoGreen,
+			alignItems: "center",
+			justifyContent: "center",
+			elevation: 2,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.2,
+			shadowRadius: 2,
+		},
+		sendButtonText: {
+			color: "white",
+			fontWeight: "700",
+			fontSize: 16,
+		},
+	});

--- a/app/pages/opinion.tsx
+++ b/app/pages/opinion.tsx
@@ -13,21 +13,36 @@ import {
 } from "react-native-paper";
 import LocationMap from "@/components/LocationMap";
 import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import { userInfo } from "@/testUserInfo";
 import { userApiClient } from "../apiClients/UserApiClient";
 import { useLocationContext } from "../contexts/LocationContext";
 import { useOpinionContext } from "../contexts/OpinionContext";
 
-const Loading = () => (
-	<PaperProvider>
-		<View style={styles.center}>
-			<ActivityIndicator animating size="large" />
-			<Text>位置情報を取得中...</Text>
-		</View>
-	</PaperProvider>
-);
+const Loading = () => {
+	const colorScheme = useColorScheme();
+	const colors = Colors[colorScheme ?? "light"];
+	const styles = createStyles(colors);
+
+	return (
+		<PaperProvider>
+			<View style={styles.center}>
+				<ActivityIndicator animating size="large" color={colors.tokyoGreen} />
+				<Text
+					style={{ color: colors.tokyoGreenDark, fontSize: 16, marginTop: 12 }}
+				>
+					位置情報を取得中...
+				</Text>
+			</View>
+		</PaperProvider>
+	);
+};
 
 export default function OpinionScreen() {
+	const colorScheme = useColorScheme();
+	const colors = Colors[colorScheme ?? "light"];
+	const styles = createStyles(colors);
+
 	const { location, setLocation } = useLocationContext();
 	const { triggerRefresh } = useOpinionContext();
 
@@ -124,31 +139,52 @@ export default function OpinionScreen() {
 	return <PaperProvider>{!location ? Loading() : DefaultView()}</PaperProvider>;
 }
 
-const styles = StyleSheet.create({
-	container: {
-		flex: 1,
-		backgroundColor: Colors.light.background, // 背景色を設定
-	},
-	mapContainer: { flex: 2 },
-	formContainer: {
-		flex: 1,
-		margin: 16,
-		justifyContent: "center",
-		backgroundColor: Colors.light.background, // フォームの背景色を設定
-	},
-	input: {
-		marginBottom: 16,
-		height: 100,
-		textAlignVertical: "top",
-		color: Colors.light.text, // テキスト色を設定
-	},
-	button: {
-		marginTop: 8,
-		backgroundColor: Colors.light.tint, // ボタンの色を設定
-	},
-	center: {
-		flex: 1,
-		justifyContent: "center",
-		alignItems: "center",
-	},
-});
+// 東京都アプリスタイルのスタイルシート
+const createStyles = (colors: any) =>
+	StyleSheet.create({
+		container: {
+			flex: 1,
+			backgroundColor: colors.tokyoLightGreen,
+		},
+		mapContainer: {
+			flex: 2,
+			borderRadius: 12,
+			margin: 8,
+			overflow: "hidden",
+			elevation: 4,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.1,
+			shadowRadius: 4,
+		},
+		formContainer: {
+			flex: 1,
+			margin: 16,
+			justifyContent: "center",
+			backgroundColor: colors.cardBackground,
+			borderRadius: 16,
+			elevation: 6,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.15,
+			shadowRadius: 8,
+			borderTopWidth: 3,
+			borderTopColor: colors.tokyoGreen,
+		},
+		input: {
+			marginBottom: 20,
+			height: 120,
+			textAlignVertical: "top",
+			backgroundColor: "white",
+		},
+		button: {
+			marginTop: 12,
+			backgroundColor: colors.tokyoGreen,
+			borderRadius: 8,
+			paddingVertical: 4,
+		},
+		center: {
+			flex: 1,
+			justifyContent: "center",
+			alignItems: "center",
+			backgroundColor: colors.tokyoLightGreen,
+		},
+	});

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -1,11 +1,19 @@
 import { StyleSheet, Text, type TextProps } from "react-native";
-
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import { useThemeColor } from "@/hooks/useThemeColor";
 
 type ThemedTextProps = TextProps & {
 	lightColor?: string;
 	darkColor?: string;
-	type?: "default" | "title" | "defaultSemiBold" | "subtitle" | "link";
+	type?:
+		| "default"
+		| "title"
+		| "defaultSemiBold"
+		| "subtitle"
+		| "link"
+		| "tokyoTitle"
+		| "tokyoSubtitle";
 };
 
 export function ThemedText({
@@ -15,7 +23,10 @@ export function ThemedText({
 	type = "default",
 	...rest
 }: ThemedTextProps) {
+	const colorScheme = useColorScheme();
+	const colors = Colors[colorScheme ?? "light"];
 	const color = useThemeColor({ light: lightColor, dark: darkColor }, "text");
+	const styles = createStyles(colors);
 
 	return (
 		<Text
@@ -26,6 +37,8 @@ export function ThemedText({
 				type === "defaultSemiBold" ? styles.defaultSemiBold : undefined,
 				type === "subtitle" ? styles.subtitle : undefined,
 				type === "link" ? styles.link : undefined,
+				type === "tokyoTitle" ? styles.tokyoTitle : undefined,
+				type === "tokyoSubtitle" ? styles.tokyoSubtitle : undefined,
 				style,
 			]}
 			{...rest}
@@ -33,28 +46,50 @@ export function ThemedText({
 	);
 }
 
-const styles = StyleSheet.create({
-	default: {
-		fontSize: 16,
-		lineHeight: 24,
-	},
-	defaultSemiBold: {
-		fontSize: 16,
-		lineHeight: 24,
-		fontWeight: "600",
-	},
-	title: {
-		fontSize: 32,
-		fontWeight: "bold",
-		lineHeight: 32,
-	},
-	subtitle: {
-		fontSize: 20,
-		fontWeight: "bold",
-	},
-	link: {
-		lineHeight: 30,
-		fontSize: 16,
-		color: "#0a7ea4",
-	},
-});
+// 東京都アプリスタイルのスタイルシート
+const createStyles = (colors: any) =>
+	StyleSheet.create({
+		default: {
+			fontSize: 16,
+			lineHeight: 24,
+			fontWeight: "400",
+		},
+		defaultSemiBold: {
+			fontSize: 16,
+			lineHeight: 24,
+			fontWeight: "600",
+		},
+		title: {
+			fontSize: 32,
+			fontWeight: "700",
+			lineHeight: 38,
+			color: colors.tokyoGreenDark,
+		},
+		subtitle: {
+			fontSize: 20,
+			fontWeight: "600",
+			lineHeight: 26,
+			color: colors.tokyoGreen,
+		},
+		link: {
+			lineHeight: 30,
+			fontSize: 16,
+			color: colors.tokyoGreen,
+			fontWeight: "600",
+		},
+		// 東京都アプリ専用スタイル
+		tokyoTitle: {
+			fontSize: 28,
+			fontWeight: "700",
+			lineHeight: 34,
+			color: colors.tokyoGreen,
+			textAlign: "center",
+		},
+		tokyoSubtitle: {
+			fontSize: 18,
+			fontWeight: "600",
+			lineHeight: 24,
+			color: colors.tokyoGreenDark,
+			textAlign: "center",
+		},
+	});

--- a/components/ThemedView.tsx
+++ b/components/ThemedView.tsx
@@ -1,22 +1,69 @@
-import { View, type ViewProps } from "react-native";
-
+import { StyleSheet, View, type ViewProps } from "react-native";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 import { useThemeColor } from "@/hooks/useThemeColor";
 
 type ThemedViewProps = ViewProps & {
 	lightColor?: string;
 	darkColor?: string;
+	type?: "default" | "card" | "tokyoCard" | "tokyoBackground";
 };
 
 export function ThemedView({
 	style,
 	lightColor,
 	darkColor,
+	type = "default",
 	...otherProps
 }: ThemedViewProps) {
+	const colorScheme = useColorScheme();
+	const colors = Colors[colorScheme ?? "light"];
 	const backgroundColor = useThemeColor(
 		{ light: lightColor, dark: darkColor },
 		"background",
 	);
+	const styles = createStyles(colors);
 
-	return <View style={[{ backgroundColor }, style]} {...otherProps} />;
+	return (
+		<View
+			style={[
+				{ backgroundColor },
+				type === "card" ? styles.card : undefined,
+				type === "tokyoCard" ? styles.tokyoCard : undefined,
+				type === "tokyoBackground" ? styles.tokyoBackground : undefined,
+				style,
+			]}
+			{...otherProps}
+		/>
+	);
 }
+
+// 東京都アプリスタイルのスタイルシート
+const createStyles = (colors: any) =>
+	StyleSheet.create({
+		card: {
+			backgroundColor: colors.cardBackground,
+			borderRadius: 12,
+			padding: 16,
+			elevation: 4,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.1,
+			shadowRadius: 4,
+			shadowOffset: { width: 0, height: 2 },
+		},
+		tokyoCard: {
+			backgroundColor: colors.cardBackground,
+			borderRadius: 16,
+			padding: 20,
+			elevation: 6,
+			shadowColor: colors.shadowColor,
+			shadowOpacity: 0.15,
+			shadowRadius: 8,
+			shadowOffset: { width: 0, height: 3 },
+			borderTopWidth: 3,
+			borderTopColor: colors.tokyoGreen,
+		},
+		tokyoBackground: {
+			backgroundColor: colors.tokyoLightGreen,
+		},
+	});

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -3,7 +3,12 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = "#17882e";
+// 東京都アプリのカラーパレット
+const tokyoGreen = "#00B04F"; // 東京都アプリのメインカラー
+const tokyoGreenLight = "#17B04F"; // 少し明るい緑
+const tokyoGreenDark = "#008A3F"; // 少し暗い緑
+const tokyoLightGreen = "#E8F5E8"; // 薄い緑色背景
+const tintColorLight = tokyoGreen;
 const tintColorDark = "#fff";
 
 export const Colors = {
@@ -14,6 +19,13 @@ export const Colors = {
 		icon: "#687076",
 		tabIconDefault: "#687076",
 		tabIconSelected: tintColorLight,
+		// 東京都アプリ専用カラー
+		tokyoGreen: tokyoGreen,
+		tokyoGreenLight: tokyoGreenLight,
+		tokyoGreenDark: tokyoGreenDark,
+		tokyoLightGreen: tokyoLightGreen,
+		cardBackground: "#fff",
+		shadowColor: "rgba(0, 0, 0, 0.1)",
 	},
 	dark: {
 		text: "#ECEDEE",
@@ -22,5 +34,12 @@ export const Colors = {
 		icon: "#9BA1A6",
 		tabIconDefault: "#9BA1A6",
 		tabIconSelected: tintColorDark,
+		// 東京都アプリ専用カラー（ダークモード）
+		tokyoGreen: tokyoGreenLight,
+		tokyoGreenLight: tokyoGreenDark,
+		tokyoGreenDark: tokyoGreen,
+		tokyoLightGreen: "#1A3A1A",
+		cardBackground: "#2A2A2A",
+		shadowColor: "rgba(255, 255, 255, 0.1)",
 	},
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 東京テーマのカラーパレットを追加し、ライト/ダークに対応
  - ThemedText に tokyoTitle/tokyoSubtitle を追加
  - ThemedView に card/tokyoCard/tokyoBackground タイプを追加
- UI 改善
  - タブバーの色・背景・影・ラベルスタイルを刷新（iOS/他プラットフォーム最適化）
  - チャット画面にヘッダー追加、メッセージ/入力エリアをテーマ対応で再設計
  - 意見投稿・地図画面のボタン/入力/カードの見た目をテーマ連動に統一
  - 全体のボタン、入力、ラベルの可読性と一貫性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->