### PR TITLE
フォームコンテナのマージンを調整

### DIFF
--- a/app/pages/opinion.tsx
+++ b/app/pages/opinion.tsx
@@ -104,7 +104,7 @@ export default function OpinionScreen() {
 	const DefaultView = () => (
 		<KeyboardAvoidingView
 			style={styles.container}
-			behavior={Platform.OS === "ios" ? "padding" : "padding"}
+			behavior={Platform.OS === "ios" ? "padding" : "height"}
 		>
 			<LocationMap
 				markerCoords={markerCoords}
@@ -157,8 +157,8 @@ const createStyles = (colors: any) =>
 			shadowRadius: 4,
 		},
 		formContainer: {
-			marginHorizontal: 18,
-			marginVertical: 10,
+			marginHorizontal: 16,
+			marginVertical: 12,
 			backgroundColor: colors.cardBackground,
 			borderRadius: 16,
 			elevation: 6,

--- a/app/pages/opinion.tsx
+++ b/app/pages/opinion.tsx
@@ -157,9 +157,8 @@ const createStyles = (colors: any) =>
 			shadowRadius: 4,
 		},
 		formContainer: {
-			flex: 1,
-			margin: 16,
-			justifyContent: "center",
+			marginHorizontal: 18,
+			marginVertical: 10,
 			backgroundColor: colors.cardBackground,
 			borderRadius: 16,
 			elevation: 6,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 意見ページのフォーム周りのレイアウトを調整：横方向と縦方向の余白を明確化し、flexによる全高拡張と中央寄せを解除して表示の一貫性を向上。
  * キーボード表示時のレイアウト調整方法を非iOS端末で変更し、入力時の画面挙動を改善（iOSは従来通り）。
  * 見た目と表示振る舞いの改善のみで、機能・操作・データ処理に影響はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->