### PR TITLE
意見送信時の成功メッセージとエラーメッセージの表示機能を追加

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,6 +17,7 @@ import {
 	TouchableOpacity,
 	View,
 } from "react-native";
+import { Snackbar } from "react-native-paper";
 import { Colors } from "@/constants/Colors";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { userInfo } from "@/testUserInfo";
@@ -73,7 +74,8 @@ function LocationMap() {
 	const colors = Colors[colorScheme ?? "light"];
 	const styles = createStyles(colors);
 	const { location, setLocation } = useLocationContext();
-	const { shouldRefresh, resetRefresh } = useOpinionContext();
+	const { shouldRefresh, resetRefresh, successMessage, setSuccessMessage } =
+		useOpinionContext();
 	const [posts, setPosts] = useState<Spot[]>([]);
 	const [selected, setSelected] = useState<Spot | null>(null);
 	const [loading, setLoading] = useState(false);
@@ -196,6 +198,17 @@ function LocationMap() {
 			setMapKey((prev) => prev + 1);
 		}
 	}, [shouldRefresh, location, fetchOpinion, resetRefresh]);
+
+	// 成功メッセージの表示
+	useEffect(() => {
+		if (successMessage) {
+			// 少し遅延してからsnackbarを表示
+			const timer = setTimeout(() => {
+				setSuccessMessage(null);
+			}, 3000);
+			return () => clearTimeout(timer);
+		}
+	}, [successMessage, setSuccessMessage]);
 
 	useEffect(() => {
 		if (selected?.id) {
@@ -385,6 +398,17 @@ function LocationMap() {
 						</View>
 					</View>
 				)}
+
+				<Snackbar
+					visible={!!successMessage}
+					onDismiss={() => setSuccessMessage(null)}
+					duration={3000}
+					style={{
+						backgroundColor: colors.tokyoGreen,
+					}}
+				>
+					{successMessage || ""}
+				</Snackbar>
 			</View>
 		</KeyboardAvoidingView>
 	);

--- a/app/contexts/OpinionContext.tsx
+++ b/app/contexts/OpinionContext.tsx
@@ -4,12 +4,15 @@ interface OpinionContextType {
 	shouldRefresh: boolean;
 	triggerRefresh: () => void;
 	resetRefresh: () => void;
+	successMessage: string | null;
+	setSuccessMessage: (message: string | null) => void;
 }
 
 const OpinionContext = createContext<OpinionContextType | undefined>(undefined);
 
 export function OpinionProvider({ children }: { children: ReactNode }) {
 	const [shouldRefresh, setShouldRefresh] = useState(false);
+	const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
 	const triggerRefresh = () => {
 		setShouldRefresh(true);
@@ -21,7 +24,13 @@ export function OpinionProvider({ children }: { children: ReactNode }) {
 
 	return (
 		<OpinionContext.Provider
-			value={{ shouldRefresh, triggerRefresh, resetRefresh }}
+			value={{
+				shouldRefresh,
+				triggerRefresh,
+				resetRefresh,
+				successMessage,
+				setSuccessMessage,
+			}}
 		>
 			{children}
 		</OpinionContext.Provider>

--- a/app/pages/opinion.tsx
+++ b/app/pages/opinion.tsx
@@ -8,6 +8,7 @@ import {
 	Button,
 	Card,
 	Provider as PaperProvider,
+	Snackbar,
 	Text,
 	TextInput,
 } from "react-native-paper";
@@ -44,10 +45,15 @@ export default function OpinionScreen() {
 	const styles = createStyles(colors);
 
 	const { location, setLocation } = useLocationContext();
-	const { triggerRefresh } = useOpinionContext();
+	const { triggerRefresh, setSuccessMessage } = useOpinionContext();
 
 	const [feedback, setFeedback] = useState("");
 	const [sending, setSending] = useState(false);
+	const [snackbarVisible, setSnackbarVisible] = useState(false);
+	const [snackbarMessage, setSnackbarMessage] = useState("");
+	const [snackbarType, setSnackbarType] = useState<"success" | "error">(
+		"success",
+	);
 
 	const [markerCoords, setMarkerCoords] = useState<LatLng | null>(null);
 	const [isInitialized, setIsInitialized] = useState(false);
@@ -72,7 +78,9 @@ export default function OpinionScreen() {
 	// 意見を送信する関数
 	const handleSendOpinion = async () => {
 		if (!markerCoords) {
-			alert("位置情報が未設定です");
+			setSnackbarMessage("位置情報が未設定です");
+			setSnackbarType("error");
+			setSnackbarVisible(true);
 			return;
 		}
 
@@ -91,11 +99,14 @@ export default function OpinionScreen() {
 			setFeedback("");
 			// メイン画面の意見一覧更新をトリガー
 			triggerRefresh();
-			// 投稿成功のフィードバックを表示してから前の画面に戻る
-			alert("意見を送信しました！");
+			// 成功メッセージをcontextに設定
+			setSuccessMessage("意見を送信しました！");
+			// 前の画面に戻る
 			router.back();
 		} catch (error) {
-			alert(`意見の送信に失敗しました。${error}`);
+			setSnackbarMessage(`意見の送信に失敗しました。${error}`);
+			setSnackbarType("error");
+			setSnackbarVisible(true);
 		} finally {
 			setSending(false);
 		}
@@ -133,6 +144,18 @@ export default function OpinionScreen() {
 					</Button>
 				</Card.Content>
 			</Card>
+
+			<Snackbar
+				visible={snackbarVisible}
+				onDismiss={() => setSnackbarVisible(false)}
+				duration={3000}
+				style={{
+					backgroundColor:
+						snackbarType === "success" ? colors.tokyoGreen : "#f44336",
+				}}
+			>
+				{snackbarMessage}
+			</Snackbar>
 		</KeyboardAvoidingView>
 	);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - スナックバー通知を導入。送信成功・エラー時に画面下部へメッセージを表示し、3秒で自動消去します。
  - 意見送信後はアラートではなく「意見を送信しました！」をスナックバーで表示し、戻った後もトップ/地図画面で成功メッセージを確認可能。
  - 成功は緑、エラーは赤の背景で視認性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->